### PR TITLE
修复 About页面toobar回退键 点击无效

### DIFF
--- a/app/src/main/java/cn/droidlover/xdroidmvp/demo/ui/AboutActivity.java
+++ b/app/src/main/java/cn/droidlover/xdroidmvp/demo/ui/AboutActivity.java
@@ -3,6 +3,7 @@ package cn.droidlover.xdroidmvp.demo.ui;
 import android.app.Activity;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
+import android.view.MenuItem;
 import android.view.View;
 
 import butterknife.BindView;
@@ -28,6 +29,7 @@ public class AboutActivity extends XActivity {
     private void initToolbar() {
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        getSupportActionBar().setHomeButtonEnabled(true);
         getSupportActionBar().setHomeAsUpIndicator(R.drawable.ic_arrow_white_24dp);
         getSupportActionBar().setTitle("关于XDroidMvp");
     }
@@ -64,5 +66,14 @@ public class AboutActivity extends XActivity {
     @Override
     public Object newP() {
         return null;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 }


### PR DESCRIPTION
在AboutActivity 中的initToolbar()方法中添加了一个
 getSupportActionBar().setHomeButtonEnabled(true);//决定左上角的图标是否可以点击

复写了一个 onOptionsItemSelected方法
@Override
public boolean onOptionsItemSelected(MenuItem item)
{
    if (item.getItemId() == android.R.id.home)
    {
        finish();
        return true;
    }
    return super.onOptionsItemSelected(item);
}